### PR TITLE
Add CI pipeline to check whether codes adheres to the Blue style

### DIFF
--- a/.github/workflows/blue_style_check.yml
+++ b/.github/workflows/blue_style_check.yml
@@ -1,0 +1,22 @@
+name: blue-style-check
+
+on:
+  pull_request: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1.9'
+          arch: 'x64'
+      - name: Install JuliaFormatter
+        # This will use the latest version by default but you can set the version like so:
+        # julia -e 'using Pkg; Pkg.add("JuliaFormatter", version="1.0.35")'
+        run: |
+          julia -e 'using Pkg; Pkg.add("JuliaFormatter")'
+      - name: Format check
+        run: |
+          julia -e 'using JuliaFormatter; format(".", BlueStyle(), verbose=false, overwrite=false)'

--- a/.github/workflows/blue_style_check.yml
+++ b/.github/workflows/blue_style_check.yml
@@ -1,6 +1,9 @@
 name: blue-style-check
 
 on:
+  push:
+    branches:
+      - main
   pull_request: {}
 
 jobs:

--- a/.github/workflows/blue_style_check.yml
+++ b/.github/workflows/blue_style_check.yml
@@ -7,7 +7,7 @@ on:
   pull_request: {}
 
 jobs:
-  build:
+  BlueStyleCheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/blue_style_check.yml
+++ b/.github/workflows/blue_style_check.yml
@@ -22,4 +22,11 @@ jobs:
           julia -e 'using Pkg; Pkg.add("JuliaFormatter")'
       - name: Format check
         run: |
-          julia -e 'using JuliaFormatter; format(".", BlueStyle(), verbose=false, overwrite=false)'
+          julia -e '
+          using JuliaFormatter
+          return_code = format(".", BlueStyle(), verbose=false, overwrite=false)
+          if return_code
+              exit(0)
+          else
+              exit(1)
+          end'


### PR DESCRIPTION
Closes #20 

This PR adds a GitHub action that installs [JuliaFormatter](https://github.com/domluna/JuliaFormatter.jl) and runs it against all `.jl` files in the repo and checks whether they adhere to the Blue style. Currently, as expected, the job fails because there are some files that do not follow the standard. I will fix those files and submit a new PR next week, explaining also how you can do it yourselves.