### PR TITLE
Format using JuliaFormatter and Blue style

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,14 +14,7 @@ makedocs(;
         edit_link="main",
         assets=String[],
     ),
-    pages=[
-        "Home" => "index.md",
-        "Functions" => "functions.md",
-        "Usage" => "usage.md"
-    ],
+    pages=["Home" => "index.md", "Functions" => "functions.md", "Usage" => "usage.md"],
 )
 
-deploydocs(;
-    repo="github.com/janablechschmidt/MetaRange.jl",
-    devbranch="main",
-)
+deploydocs(; repo="github.com/janablechschmidt/MetaRange.jl", devbranch="main")

--- a/src/datastructure_constructors.jl
+++ b/src/datastructure_constructors.jl
@@ -30,7 +30,6 @@ function get_Simulation_Parameters(config::Dict)
     )
 end
 
-
 """
     get_Traits(species::Dict)
 
@@ -40,7 +39,6 @@ function get_Traits(species::Dict)
     return Traits(
         species["mass"],
         species["sd_mass"],
-
         species["growrate"],
         species["sd_growrate"],
         species["param_const_growrate"],
@@ -49,22 +47,17 @@ function get_Traits(species::Dict)
         species["max_dispersal_dist"],
         species["max_dispersal_buffer"],
         species["mean_dispersal_dist"],
-
         species["allee"],
         species["sd_allee"],
         species["param_const_allee"],
-
         species["bevmort"],
         species["sd_bevmort"],
         species["param_const_bevmort"],
-
         species["carry"],
         species["sd_carry"],
         species["param_const_carry"],
-
         species["env_preferences"],
-
-        species["habitat_cutoff_suitability"]
+        species["habitat_cutoff_suitability"],
     )
 end
 
@@ -76,9 +69,7 @@ as an Env_Preferences object.
 """
 function get_Env_Preferences(species::Dict, key::String)
     return Env_Preferences(
-        species["upper_limit_$key"],
-        species["lower_limit_$key"],
-        species["optimum_$key"],
+        species["upper_limit_$key"], species["lower_limit_$key"], species["optimum_$key"]
     )
 end
 
@@ -101,6 +92,6 @@ function get_Simulation_Variables()
         Array{Float64}(undef, 0, 0), # allee
         Array{Float64}(undef, 0, 0), # bevmort
         Vector{CartesianIndex{2}}(undef, 0), # occurrences
-        Array{Float64}(undef, 0, 0) # offspring
+        Array{Float64}(undef, 0, 0), # offspring
     )
 end

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -54,7 +54,7 @@ struct Traits
     "Species Parameter standard deviation"
     sd_growrate::Float64 # Species Parameter std dev
     "Species Parameter"
-    param_const_growrate::Union{Float64, Nothing}  # Species Parameter
+    param_const_growrate::Union{Float64,Nothing}  # Species Parameter
 
     #prob_dispersal::Float64 # Species Parameter
     "Species Parameter"
@@ -69,24 +69,24 @@ struct Traits
     "Allee effect standard deviation"
     sd_allee::Float64
     "Species parameter"
-    param_const_allee::Union{Float64, Nothing} # Species Parameter
+    param_const_allee::Union{Float64,Nothing} # Species Parameter
 
     "Beverton mortality"
     bevmort::Float64
     "Beverton mortality standard deviation"
     sd_bevmort::Float64
     "Species Parameter"
-    param_const_bevmort::Union{Float64, Nothing} # Species Parameter
+    param_const_bevmort::Union{Float64,Nothing} # Species Parameter
 
     "Species Parameter"
     carry::Float64 # Species Parameter
     "Species Parameter standard deviation"
     sd_carry::Float64 # Species Parameter std dev
     "Species Parameter"
-    param_const_carry::Union{Float64, Nothing} # Species Parameter
+    param_const_carry::Union{Float64,Nothing} # Species Parameter
 
     "Dictionary of environmental preferences"
-    env_preferences::Dict{String, Env_Preferences}
+    env_preferences::Dict{String,Env_Preferences}
 
     "Species Parameter"
     habitat_cutoff_suitability::Float64 # Species Parameter
@@ -115,27 +115,27 @@ timestep
 """
 mutable struct Simulation_Variables
     "habitability of landscape cells for a species at current sim timestep"
-    habitat::Array{Float64, 2}
+    habitat::Array{Float64,2}
     "if landscape cells are habitable for a species at current sim timestep"
     is_habitat::BitArray{2}
     "if landscape cells are habitable for a species at next sim timestep"
-    future_habitat::Array{Float64, 2}
+    future_habitat::Array{Float64,2}
     "if landscape cells are habitable for a species at next sim timestep"
     future_is_habitat::BitArray{2}
     "biomass of a species individual at landscape cells"
-    biomass::Array{Float64, 2}
+    biomass::Array{Float64,2}
     "growrate of species at landscape cells"
-    growrate::Array{Float64, 2}
+    growrate::Array{Float64,2}
     "carry property of species at landscape cells"
-    carry::Array{Float64, 2}
+    carry::Array{Float64,2}
     "allee property of species at landscape cells"
-    allee::Array{Float64, 2}
+    allee::Array{Float64,2}
     "Beverton mortaility of species at landscape cells"
-    bevmort::Array{Float64, 2}
+    bevmort::Array{Float64,2}
     "list of cells where species occurs at current timestep"
     occurrences::Vector{CartesianIndex{2}}
     "offspring of species at current timestep"
-    offspring::Array{Float64, 2}
+    offspring::Array{Float64,2}
 end
 
 ## Struct for saving all data related to a species
@@ -156,8 +156,8 @@ each timestep
 struct Species
     species_name::String
     traits::Traits
-    abundances::Array{Union{Int64, Missing}, 3} #amount of species individuals
-    habitat::Array{Float64, 3} # habitat suitability in each timestep
+    abundances::Array{Union{Int64,Missing},3} #amount of species individuals
+    habitat::Array{Float64,3} # habitat suitability in each timestep
     dispersal_kernel::Matrix{Float64}
     vars::Simulation_Variables
 end
@@ -167,8 +167,8 @@ end
 struct Landscape
     xlength::Int64 # equivalent to size[2] of any Array in this struct
     ylength::Int64 # equivalent to size[1] of any Array in this struct
-    environment::Dict{String, Array{Float64, 3}} # contains all environment attributes, addressable by name
-    restrictions::Array{Float64, 3}
+    environment::Dict{String,Array{Float64,3}} # contains all environment attributes, addressable by name
+    restrictions::Array{Float64,3}
     #biomass_capacity::Matrix{Float64} # contains biomass_capacity of current timestep in simulation
 end
 
@@ -181,8 +181,8 @@ struct Simulation_Parameters
     species_dir::String # directory of species definitions used in the simulation
     environment_dir::String # directory of environment definitions
     input_backup::Bool # Toggle if input should be included in the output folder
-    env_attribute_files::Dict{String, String}
-    env_restriction_files::Dict{String, String}
+    env_attribute_files::Dict{String,String}
+    env_restriction_files::Dict{String,String}
     env_attribute_mode::String
     env_restriction_mode::String
     attribute_restriction_blending::String

--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -5,27 +5,27 @@
 Returns a Dictionary with default simulation parameters.
 """
 function get_default_simulation_parameters()
-    A = Dict{String, Any}(
-    "experiment_name" => "default",
-    "config_dir" => nothing,
-    "output_dir" => "./output/",
-    "species_dir" => nothing,
-    "environment_dir" => nothing, # Default value gets built in the read_sp function!
-    "input_backup" => false,
-    "env_attribute_mode" => "minimum",
-    "env_restriction_mode" => "minimum",
-    "env_attribute_files" => "",
-    "attribute_restriction_blending" => "multiplication",
-    # "ls_timeseries_config" => "default",
-    "timesteps" => 20,
-    "randomseed" => 42,
-    "reproduction_model" => "Beverton",
-    "use_metabolic_theory" => true,
-    "use_stoch_allee" => false,
-    "use_stoch_carry" => false,
-    "use_stoch_num" => false,
-    "initialize_cells" => "habitat",
-    #"ls_cell_biomass_cap" => 200.0
+    return A = Dict{String,Any}(
+        "experiment_name" => "default",
+        "config_dir" => nothing,
+        "output_dir" => "./output/",
+        "species_dir" => nothing,
+        "environment_dir" => nothing, # Default value gets built in the read_sp function!
+        "input_backup" => false,
+        "env_attribute_mode" => "minimum",
+        "env_restriction_mode" => "minimum",
+        "env_attribute_files" => "",
+        "attribute_restriction_blending" => "multiplication",
+        # "ls_timeseries_config" => "default",
+        "timesteps" => 20,
+        "randomseed" => 42,
+        "reproduction_model" => "Beverton",
+        "use_metabolic_theory" => true,
+        "use_stoch_allee" => false,
+        "use_stoch_carry" => false,
+        "use_stoch_num" => false,
+        "initialize_cells" => "habitat",
+        #"ls_cell_biomass_cap" => 200.0
     )
 end
 
@@ -42,31 +42,31 @@ function get_testrun_simulation_parameters()
     #  "precipitation" => "none",
     #  "temperature" => "none")
     #  env_restriction_files = Dict{String, String}()
-    A = Dict{String, Any}(
-    "experiment_name" => "testrun",
-    "config_dir" => nothing,
-    "output_dir" => "./output/",
-    "species_dir" => "notreal",
-    "environment_dir" => "notreal",
-    "input_backup" => false,
-    "env_attribute_mode" => "minimum",
-    "env_restriction_mode" => "minimum",
-    "env_attribute_files" => Dict{String, String}(),
-    "env_restriction_files" => Dict{String, String}(),
-    "attribute_restriction_blending" => "multiplication",
-    "timesteps" => 20,
-    "randomseed" => 42,
-    "reproduction_model" => "Beverton",
-    "use_metabolic_theory" => true,
-    "use_stoch_allee" => false,
-    "use_stoch_carry" => false,
-    "use_stoch_num" => false,
-    "initialize_cells" => "habitat",
-    #"ls_cell_biomass_cap" => 200.0
+    A = Dict{String,Any}(
+        "experiment_name" => "testrun",
+        "config_dir" => nothing,
+        "output_dir" => "./output/",
+        "species_dir" => "notreal",
+        "environment_dir" => "notreal",
+        "input_backup" => false,
+        "env_attribute_mode" => "minimum",
+        "env_restriction_mode" => "minimum",
+        "env_attribute_files" => Dict{String,String}(),
+        "env_restriction_files" => Dict{String,String}(),
+        "attribute_restriction_blending" => "multiplication",
+        "timesteps" => 20,
+        "randomseed" => 42,
+        "reproduction_model" => "Beverton",
+        "use_metabolic_theory" => true,
+        "use_stoch_allee" => false,
+        "use_stoch_carry" => false,
+        "use_stoch_num" => false,
+        "initialize_cells" => "habitat",
+        #"ls_cell_biomass_cap" => 200.0
     )
     config_path = "./TESTRUN"
     if !isdir(config_path)
-      mkdir(config_path)
+        mkdir(config_path)
     end
     A["config_dir"] = config_path
     sp_sanity_checks!(A)
@@ -75,11 +75,7 @@ function get_testrun_simulation_parameters()
 end
 
 function get_default_ls_timeseries_config()
-    return Dict{String, Any}(
-    "prediction" => 0,
-    "change_onset" => 0,
-    "sd" => 0
-    )
+    return Dict{String,Any}("prediction" => 0, "change_onset" => 0, "sd" => 0)
 end
 
 """
@@ -88,22 +84,22 @@ end
 Creates a Default Landscape with random values and some NAs for testing.
 """
 function get_default_LS()
-    environment = Dict{String, Array{Float64, 3}}()
-    landscape_size = (20,20)
+    environment = Dict{String,Array{Float64,3}}()
+    landscape_size = (20, 20)
     timesteps = 25
     # TODO maybe make randomness not over time?
     environment["temperature"] = fill(293.15, landscape_size..., timesteps)
     environment["temperature"] .+= randn(size(environment["temperature"])) .* 2.5
-    environment["precipitation" ] = fill(500, landscape_size..., timesteps)
+    environment["precipitation"] = fill(500, landscape_size..., timesteps)
     environment["precipitation"] .+= randn(size(environment["precipitation"])) .* 100
     restrictions = ones(Float64, landscape_size..., timesteps)
-    environment["temperature"][14:16,14:16,1:25] .= NaN
-    environment["precipitation"][14:16,14:16,1:25] .= NaN
+    environment["temperature"][14:16, 14:16, 1:25] .= NaN
+    environment["precipitation"][14:16, 14:16, 1:25] .= NaN
     return Landscape(
-    landscape_size[2], #xlength
-    landscape_size[1], #ylength
-    environment,
-    restrictions,
+        landscape_size[2], #xlength
+        landscape_size[1], #ylength
+        environment,
+        restrictions,
     )
 end
 
@@ -113,27 +109,27 @@ end
 Returns a dictionary of default species traits for initialisation
 """
 function species_default()
-    return Dict{String, Any}(
-    "species_name" => "default",
-    "mass" => "0.01",
-    "sd_mass" => "0",
-    "growrate" => "1.7",
-    "sd_growrate" => "0",
-    "max_dispersal_dist" => "3",
-    "mean_dispersal_dist" => "1",
-    "allee" => "-200",
-    "sd_allee" => "0",
-    "bevmort" => "0.3",
-    "sd_bevmort" => "0",
-    "carry" => "200",
-    "sd_carry" => "0",
-    "upper_limit_temperature" => "303.15",
-    "lower_limit_temperature" => "283.15",
-    "optimum_temperature" => "293.15",
-    "upper_limit_precipitation" => "400",
-    "lower_limit_precipitation" => "600",
-    "optimum_precipitation" => "500",
-    "habitat_cutoff_suitability" => "0.001",
+    return Dict{String,Any}(
+        "species_name" => "default",
+        "mass" => "0.01",
+        "sd_mass" => "0",
+        "growrate" => "1.7",
+        "sd_growrate" => "0",
+        "max_dispersal_dist" => "3",
+        "mean_dispersal_dist" => "1",
+        "allee" => "-200",
+        "sd_allee" => "0",
+        "bevmort" => "0.3",
+        "sd_bevmort" => "0",
+        "carry" => "200",
+        "sd_carry" => "0",
+        "upper_limit_temperature" => "303.15",
+        "lower_limit_temperature" => "283.15",
+        "optimum_temperature" => "293.15",
+        "upper_limit_precipitation" => "400",
+        "lower_limit_precipitation" => "600",
+        "optimum_precipitation" => "500",
+        "habitat_cutoff_suitability" => "0.001",
     )
 end
 
@@ -149,9 +145,9 @@ function get_default_species(LS::Landscape, SP::Simulation_Parameters)
     # convert all Float and Integer arguments to their respective Julia types
     parse_species_datatypes!(species)
     # calculate properties
-    species["max_dispersal_buffer"] = species["max_dispersal_dist"]*2
+    species["max_dispersal_buffer"] = species["max_dispersal_dist"] * 2
     # calculate environment properties
-    env_preferences = Dict{String, Env_Preferences}()
+    env_preferences = Dict{String,Env_Preferences}()
     for key in keys(LS.environment)
         if key == "temperature"
             if species["lower_limit_temperature"] < 60
@@ -167,7 +163,7 @@ function get_default_species(LS::Landscape, SP::Simulation_Parameters)
     end
     species["env_preferences"] = env_preferences
     # calibrate pop params if they weren't provided
-    pop_param = ["growrate","carry","allee","bevmort"]
+    pop_param = ["growrate", "carry", "allee", "bevmort"]
     exp = Dict(
         "growrate" => exp_growrate,
         "carry" => exp_carry,
@@ -178,7 +174,7 @@ function get_default_species(LS::Landscape, SP::Simulation_Parameters)
         "growrate" => E_growrate,
         "carry" => E_carry,
         "allee" => E_allee,
-        "bevmort" => E_bevmort
+        "bevmort" => E_bevmort,
     )
     for param in pop_param
         if "param_const_$param" ∉ keys(species)
@@ -200,26 +196,23 @@ function get_default_species(LS::Landscape, SP::Simulation_Parameters)
     # Build Traits struct
     traits = get_Traits(species)
     # calculate habitat
-    habitat_init = get_habitat(traits.env_preferences,LS,SP.env_attribute_mode,1)
-    habitat = Array{Float64, 3}(
-        undef,
-        size(habitat_init)[1],
-        size(habitat_init)[2],
-        SP.timesteps
+    habitat_init = get_habitat(traits.env_preferences, LS, SP.env_attribute_mode, 1)
+    habitat = Array{Float64,3}(
+        undef, size(habitat_init)[1], size(habitat_init)[2], SP.timesteps
     )
-    habitat[:,:,1] = habitat_init
+    habitat[:, :, 1] = habitat_init
     # initialize abundances
-    abundances = InitializeAbundances(SP,habitat[:,:,1],traits.carry)
+    abundances = InitializeAbundances(SP, habitat[:, :, 1], traits.carry)
     dispersal_kernel = DispersalNegExpKernel(
-        traits.max_dispersal_dist,
-        traits.mean_dispersal_dist
+        traits.max_dispersal_dist, traits.mean_dispersal_dist
     )
     # total_abundance = Vector{Union{Nothing,Int64}}(undef,SP.timesteps)
-    push!(
+    return push!(
         species_vec,
         Species(
             species["species_name"],
-            traits,abundances,
+            traits,
+            abundances,
             habitat,
             dispersal_kernel,
             get_Simulation_Variables(),
@@ -236,7 +229,7 @@ function default_run_data()
     parameters = get_testrun_simulation_parameters()
     #duration = Duration
     species = get_default_species(landscape, parameters)
-    return Simulation_Data(parameters, landscape, species, Duration(now(),now()))
+    return Simulation_Data(parameters, landscape, species, Duration(now(), now()))
 end
 
 # what do you need for simulation data struct?

--- a/src/eco_functions.jl
+++ b/src/eco_functions.jl
@@ -6,9 +6,11 @@
 
 Returns the number of Individuals in the next generation according to the Ricker model.
 """
-function ReproductionRicker(N::Int64, growrate::Float64, carry::Float64, unused::Union{Float64,Nothing})
-  N2 = N*exp(growrate*(1-N/carry))
-  return N2
+function ReproductionRicker(
+    N::Int64, growrate::Float64, carry::Float64, unused::Union{Float64,Nothing}
+)
+    N2 = N * exp(growrate * (1 - N / carry))
+    return N2
 end
 
 """
@@ -17,9 +19,11 @@ end
 Returns the number of Individuals in the next generation according to the Ricker model.
 Includes allee effects
 """
-function ReproductionRickerAllee(N::Int64, growrate::Float64, carry::Float64, allee::Union{Float64,Nothing})
-  N2 = N*exp.(growrate*((4*(carry .- N)*(N .- allee))/((carry-allee)^2)))
-  return N2[1]
+function ReproductionRickerAllee(
+    N::Int64, growrate::Float64, carry::Float64, allee::Union{Float64,Nothing}
+)
+    N2 = N * exp.(growrate * ((4 * (carry .- N) * (N .- allee)) / ((carry - allee)^2)))
+    return N2[1]
 end
 
 """
@@ -28,12 +32,17 @@ end
 Returns the number of offspring in the next generation according to the Beverton-Holt
 model.
 """
-function ReproductionBeverton(N::Int64,growrate::Float64,carry::Float64,beverton_mort::Float64)
-   per_capa_R = growrate /
-                 (1+(growrate * N /
-                 (carry * growrate * beverton_mort/
-                 (growrate - beverton_mort))))
-   return N * per_capa_R
+function ReproductionBeverton(
+    N::Int64, growrate::Float64, carry::Float64, beverton_mort::Float64
+)
+    per_capa_R =
+        growrate / (
+            1 + (
+                growrate * N /
+                (carry * growrate * beverton_mort / (growrate - beverton_mort))
+            )
+        )
+    return N * per_capa_R
 end
 
 #TODO: What does this function actually do?
@@ -43,7 +52,7 @@ end
 Returns how many Individuals die. Includes Stochasticity
 """
 function MortalityBev(N::Int64, beverton_mort::Float64)
-  return max(0, N - rand(Binomial(round(Int64,N), beverton_mort)))
+    return max(0, N - rand(Binomial(round(Int64, N), beverton_mort)))
 end
 
 """
@@ -52,7 +61,7 @@ end
 Returns how many Individuals die. No Stochasticity
 """
 function MortalityBevNoStoch(N::Int64, beverton_mort::Float64)
-  return max(0, N - N * beverton_mort)
+    return max(0, N - N * beverton_mort)
 end
 
 """
@@ -61,8 +70,9 @@ end
 Returns the number of individuals in the next generation according to the Beverton-Holt
 model. Includes stochastic mortality.
 """
-function BV(N::Int64,growrate::Float64,carry::Float64,beverton_mort::Float64)
-  return ReproductionBeverton(N, growrate, carry, beverton_mort) + MortalityBev(N, beverton_mort)
+function BV(N::Int64, growrate::Float64, carry::Float64, beverton_mort::Float64)
+    return ReproductionBeverton(N, growrate, carry, beverton_mort) +
+           MortalityBev(N, beverton_mort)
 end
 
 """
@@ -71,10 +81,10 @@ end
 Returns the number of individuals in the next generation according to the Beverton-Holt
 model. Does not include stochastic mortality.
 """
-function BVNoStoch(N::Int64,growrate::Float64,carry::Float64,beverton_mort::Float64)
-  return ReproductionBeverton(N, growrate, carry, beverton_mort) + MortalityBevNoStoch(N, beverton_mort)
+function BVNoStoch(N::Int64, growrate::Float64, carry::Float64, beverton_mort::Float64)
+    return ReproductionBeverton(N, growrate, carry, beverton_mort) +
+           MortalityBevNoStoch(N, beverton_mort)
 end
-
 
 ## Dispersal kernels
 """
@@ -83,30 +93,30 @@ end
 TODO
 """
 function DispersalNegExpKernel(Dispersalbuffer, mean_dispersal_dist)
-  x = 2*Dispersalbuffer+1
-  y = 2*Dispersalbuffer+1
-  sum = 0
-  spDispKernel = zeros(x,y)
+    x = 2 * Dispersalbuffer + 1
+    y = 2 * Dispersalbuffer + 1
+    sum = 0
+    spDispKernel = zeros(x, y)
 
-  for i in 1:x
-    for j in 1:y
-      r = sqrt(
-      abs(i-(Dispersalbuffer+1))*abs(i-(Dispersalbuffer+1))+
-      abs(j-(Dispersalbuffer+1))*abs(j-(Dispersalbuffer+1))
-      )
-      dispersal = DispersalNegExpFunction(mean_dispersal_dist, r)
-      sum += dispersal
-      spDispKernel[i,j] = dispersal
+    for i in 1:x
+        for j in 1:y
+            r = sqrt(
+                abs(i - (Dispersalbuffer + 1)) * abs(i - (Dispersalbuffer + 1)) +
+                abs(j - (Dispersalbuffer + 1)) * abs(j - (Dispersalbuffer + 1)),
+            )
+            dispersal = DispersalNegExpFunction(mean_dispersal_dist, r)
+            sum += dispersal
+            spDispKernel[i, j] = dispersal
+        end
     end
-  end
-  spDispKernel
-  # Normalizing
-  for i in 1:x
-    for j in 1:x
-      spDispKernel[i,j] = spDispKernel[i,j]/sum
+    spDispKernel
+    # Normalizing
+    for i in 1:x
+        for j in 1:x
+            spDispKernel[i, j] = spDispKernel[i, j] / sum
+        end
     end
-  end
-  return spDispKernel
+    return spDispKernel
 end
 
 """
@@ -115,12 +125,12 @@ end
 TODO
 """
 function DispersalNegExpFunction(alpha, r)
-  N = 2*pi*(alpha*alpha)
-  p = (1/N)*exp(-r/alpha)
-  if p<0
-    p=0
-  end
-  return p
+    N = 2 * pi * (alpha * alpha)
+    p = (1 / N) * exp(-r / alpha)
+    if p < 0
+        p = 0
+    end
+    return p
 end
 
 """
@@ -129,12 +139,10 @@ end
 TODO
 """
 function KernelDispersal!(
-    N::Int64,
-    Offspring::Array{Float64,2},
-    Dispersal_kernel::Array{Float64,2}
+    N::Int64, Offspring::Array{Float64,2}, Dispersal_kernel::Array{Float64,2}
 )
-  Off = Offspring+N*Dispersal_kernel
-  return Off
+    Off = Offspring + N * Dispersal_kernel
+    return Off
 end
 
 ## recruitment
@@ -148,18 +156,20 @@ end
 TODO
 """
 function DispersalSurvivalStoch(
-    Abundances::Array{Union{Missing, Int64},2},
-    Offspring::Array{Float64,2},xy::Array{Int64,2},
-    max_dispersal_dist::Int64
+    Abundances::Array{Union{Missing,Int64},2},
+    Offspring::Array{Float64,2},
+    xy::Array{Int64,2},
+    max_dispersal_dist::Int64,
 )
-  for z in 1:size(xy,1) # welche koordinaten sind suitable, nur dort recruiten
-    y = xy[z,1]
-    x = xy[z,2]
-    Abundances[y, x] =
-    rand(Poisson(Offspring[y+max_dispersal_dist, x+max_dispersal_dist]))
-    # survival according to habitat suitability
-  end
-  return Abundances
+    for z in 1:size(xy, 1) # welche koordinaten sind suitable, nur dort recruiten
+        y = xy[z, 1]
+        x = xy[z, 2]
+        Abundances[y, x] = rand(
+            Poisson(Offspring[y + max_dispersal_dist, x + max_dispersal_dist])
+        )
+        # survival according to habitat suitability
+    end
+    return Abundances
 end
 
 """
@@ -172,17 +182,19 @@ end
 TODO
 """
 function DispersalSurvivalRound(
-    Abundances::Array{Union{Missing, Int64},2},
-    Offspring::Array{Float64,2}, xy::Array{Int64,2},
-    max_dispersal_dist::Int64
+    Abundances::Array{Union{Missing,Int64},2},
+    Offspring::Array{Float64,2},
+    xy::Array{Int64,2},
+    max_dispersal_dist::Int64,
 )
-  for z in 1:size(xy,1)
-    y = xy[z, 1]
-    x = xy[z, 2]
-    Abundances[y, x] =
-    round(Int64,Offspring[y + max_dispersal_dist, x + max_dispersal_dist])
-  end
-  return Abundances
+    for z in 1:size(xy, 1)
+        y = xy[z, 1]
+        x = xy[z, 2]
+        Abundances[y, x] = round(
+            Int64, Offspring[y + max_dispersal_dist, x + max_dispersal_dist]
+        )
+    end
+    return Abundances
 end
 
 """
@@ -197,9 +209,9 @@ Abundances: array with the number of individuals in the landscape
 Is_habitat: array with boolean values that indicate
 which cell is habitat in the next timestep
 """
-function HabitatMortality(Abundances::Matrix{Union{Missing, Int64}},Is_habitat::BitArray{2})
-  h=findall(iszero,Is_habitat)
-  h = hcat(getindex.(h, 1),getindex.(h, 2))
-  Abundances[h].=0
-  return Abundances
+function HabitatMortality(Abundances::Matrix{Union{Missing,Int64}}, Is_habitat::BitArray{2})
+    h = findall(iszero, Is_habitat)
+    h = hcat(getindex.(h, 1), getindex.(h, 2))
+    Abundances[h] .= 0
+    return Abundances
 end

--- a/src/eco_loop.jl
+++ b/src/eco_loop.jl
@@ -16,58 +16,57 @@ Main simulation function. Load, initialize and execute all data & processes that
     initialisation simulated.
 """
 function run_simulation!(SD::Simulation_Data)
-  simulation_start_time = now()
+    simulation_start_time = now()
 
-  DispersalSurvival = GetDispersalSurvival(SD.parameters.use_stoch_num)
+    DispersalSurvival = GetDispersalSurvival(SD.parameters.use_stoch_num)
 
-  Reproduction = GetReproductionModel(SD.parameters.reproduction_model)
+    Reproduction = GetReproductionModel(SD.parameters.reproduction_model)
 
-  groups = GetDisjunctChunkGroups(
-    SD.species[1].traits.max_dispersal_buffer,
-    size(SD.landscape.environment["temperature"])
+    groups = GetDisjunctChunkGroups(
+        SD.species[1].traits.max_dispersal_buffer,
+        size(SD.landscape.environment["temperature"]),
     )
 
-  ##### Eco Loop ######
-  for t in 1:(SD.parameters.timesteps - 1) # temporal loop
-    @info("timestep ",t)
+    ##### Eco Loop ######
+    for t in 1:(SD.parameters.timesteps - 1) # temporal loop
+        @info("timestep ", t)
 
-    # initialize the biomass capacity of the landsape
-    #init_landscape!(SD.landscape, SD.parameters.ls_cell_biomass_cap, t)
+        # initialize the biomass capacity of the landsape
+        #init_landscape!(SD.landscape, SD.parameters.ls_cell_biomass_cap, t)
 
-    #Evolution!() ## placeholder for potential expansion of the model to include evolution
+        #Evolution!() ## placeholder for potential expansion of the model to include evolution
 
-    # initialize the species parameter arras for this timestep for each species
-    init_species_sim_vars!(SD.species, SD.landscape, SD.parameters, t)
+        # initialize the species parameter arras for this timestep for each species
+        init_species_sim_vars!(SD.species, SD.landscape, SD.parameters, t)
 
-    start_time = now()
-    reproduce!(SD.species, Reproduction, t)
-    end_time = now()
-    @debug("Reproduction time: ", end_time-start_time)
-    ## placeholder for potential expansion of the model to include interspecies competition
-    #start_time = now()
-    #Competition!(SD.landscape, SD.species, t)
-    #end_time = now()
-    #@debug("Competition time: ", end_time-start_time)
+        start_time = now()
+        reproduce!(SD.species, Reproduction, t)
+        end_time = now()
+        @debug("Reproduction time: ", end_time - start_time)
+        ## placeholder for potential expansion of the model to include interspecies competition
+        #start_time = now()
+        #Competition!(SD.landscape, SD.species, t)
+        #end_time = now()
+        #@debug("Competition time: ", end_time-start_time)
 
-    start_time = now()
-    Disperse!(SD.species, SD.landscape, groups, t)
-    end_time = now()
-    @debug("Dispersal time: ", end_time-start_time)
+        start_time = now()
+        Disperse!(SD.species, SD.landscape, groups, t)
+        end_time = now()
+        @debug("Dispersal time: ", end_time - start_time)
 
+        ## Dispersal Survival
+        start_survival = now()
+        Survive!(SD.species, DispersalSurvival, t)
+        end_survival = now()
+        @debug("Survival time: ", end_survival - start_survival)
 
-    ## Dispersal Survival
-    start_survival = now()
-    Survive!(SD.species, DispersalSurvival, t)
-    end_survival = now()
-    @debug("Survival time: ", end_survival-start_survival)
+        #if sum(SD.species[1].abundances[:,:,t])<1 println("all individuals are dead"); break
+        #end
 
-    #if sum(SD.species[1].abundances[:,:,t])<1 println("all individuals are dead"); break
-    #end
+    end
 
-  end
-
-  simulation_end_time = now()
-  @info("elapsed time: ", simulation_end_time-simulation_start_time)
-  SD.duration.start_time = simulation_start_time
-  SD.duration.end_time = simulation_end_time
+    simulation_end_time = now()
+    @info("elapsed time: ", simulation_end_time - simulation_start_time)
+    SD.duration.start_time = simulation_start_time
+    return SD.duration.end_time = simulation_end_time
 end

--- a/src/eco_loop_functions.jl
+++ b/src/eco_loop_functions.jl
@@ -31,9 +31,9 @@ function GetReproductionModel(reproduction_model::String)
     else
         throw(
             ArgumentError(
-                reproduction_model* " is not a supported reproduction model. Currently /
-                supported are: Ricker, Beverton, and RickerAllee",
-            )
+                reproduction_model * " is not a supported reproduction model. Currently /
+                 supported are: Ricker, Beverton, and RickerAllee"
+            ),
         )
     end
 end
@@ -58,43 +58,27 @@ end
 TBW
 """
 function init_species_sim_vars!(
-    species::Array{Species},
-    LS::Landscape,
-    parameters::Simulation_Parameters,
-    timestep::Int,
+    species::Array{Species}, LS::Landscape, parameters::Simulation_Parameters, timestep::Int
 )
     start_time = now()
     for sp in species
         sp.vars.habitat = get_habitat(
-            sp.traits.env_preferences,
-            LS,
-            parameters.env_attribute_mode,
-            timestep,
+            sp.traits.env_preferences, LS, parameters.env_attribute_mode, timestep
         )
-        sp.habitat[:,:,timestep] = get_habitat(
-            sp.traits.env_preferences,
-            LS,
-            parameters.env_attribute_mode,
-            timestep,
+        sp.habitat[:, :, timestep] = get_habitat(
+            sp.traits.env_preferences, LS, parameters.env_attribute_mode, timestep
         )
         sp.vars.is_habitat = get_is_habitat(
-            sp.vars.habitat,
-            sp.traits.habitat_cutoff_suitability,
+            sp.vars.habitat, sp.traits.habitat_cutoff_suitability
         )
         sp.vars.future_habitat = get_habitat(
-            sp.traits.env_preferences,
-            LS,parameters.env_attribute_mode,
-            timestep+1,
+            sp.traits.env_preferences, LS, parameters.env_attribute_mode, timestep + 1
         )
         sp.vars.future_is_habitat = get_is_habitat(
-            sp.vars.future_habitat,
-            sp.traits.habitat_cutoff_suitability,
+            sp.vars.future_habitat, sp.traits.habitat_cutoff_suitability
         )
         sp.vars.biomass = get_biomass(
-            sp.traits.mass,
-            sp.traits.sd_mass,
-            LS.ylength,
-            LS.xlength,
+            sp.traits.mass, sp.traits.sd_mass, LS.ylength, LS.xlength
         )
         sp.vars.growrate = get_pop_var(
             sp.traits.growrate,
@@ -139,13 +123,13 @@ function init_species_sim_vars!(
             E_bevmort,
         )
         sp.vars.occurrences = findall(
-            (sp.abundances[:,:,timestep].>0) .& (sp.vars.is_habitat)
+            (sp.abundances[:, :, timestep] .> 0) .& (sp.vars.is_habitat)
         )
     end
     end_time = now()
     @debug(
         "Time needed to simulate the Simulation Variables of all species: ",
-        end_time-start_time
+        end_time - start_time
     )
 end
 
@@ -160,16 +144,13 @@ end
 Get habitat in current timestep. Return Array{Float64, 2}
 """
 function get_habitat(
-    env_pref::Dict{String, Env_Preferences},
-    LS::Landscape,
-    attribute_mode::String,
-    t::Int,
+    env_pref::Dict{String,Env_Preferences}, LS::Landscape, attribute_mode::String, t::Int
 )
     env_keys = collect(keys(LS.environment))
     habitability_arr = Array{Float64}(undef, LS.ylength, LS.xlength, length(env_keys))
     for i in 1:length(env_keys)
-        conditions = @view(LS.environment[env_keys[i]][:,:,t])
-        habitability_arr[:,:,i] = get_habitat_suit(
+        conditions = @view(LS.environment[env_keys[i]][:, :, t])
+        habitability_arr[:, :, i] = get_habitat_suit(
             env_pref[env_keys[i]].upper_limit,
             env_pref[env_keys[i]].optimum,
             env_pref[env_keys[i]].lower_limit,
@@ -178,17 +159,17 @@ function get_habitat(
     end
     habitability = 1
     if attribute_mode == "minimum"
-        habitability = dropdims(minimum(habitability_arr, dims=3), dims=3)
+        habitability = dropdims(minimum(habitability_arr; dims=3); dims=3)
     elseif attribute_mode == "multiplication"
-        habitability = habitability_arr[:,:,1]
+        habitability = habitability_arr[:, :, 1]
         for i in 2:length(env_keys)
-            habitability = habitability_arr[:,:,i] .* habitability
+            habitability = habitability_arr[:, :, i] .* habitability
         end
     else
         throw(MissingException(""))
     end
-    restrictions = @view(LS.restrictions[:,:,t])
-    return habitability.*restrictions
+    restrictions = @view(LS.restrictions[:, :, t])
+    return habitability .* restrictions
 end
 
 """
@@ -197,7 +178,7 @@ end
 TBW
 """
 function get_is_habitat(habitat, habitat_cutoff_suitability)
-    return habitat.>habitat_cutoff_suitability
+    return habitat .> habitat_cutoff_suitability
 end
 
 """
@@ -235,19 +216,20 @@ function get_pop_var(
     LS::Landscape,
     mass::Array{Float64,2},
     use_metabolic_theory::Bool,
-    timestep::Int, E::Float64,
+    timestep::Int,
+    E::Float64,
 )
     if use_metabolic_theory
-        temperature = @view(LS.environment["temperature"][:,:,timestep])
-        pop_param = MetabolicRate(param_const_trait,exp_trait,mass,temperature,E)
+        temperature = @view(LS.environment["temperature"][:, :, timestep])
+        pop_param = MetabolicRate(param_const_trait, exp_trait, mass, temperature, E)
     else
-        ar = Array{Float64}(undef,LS.ylength,LS.xlength)
+        ar = Array{Float64}(undef, LS.ylength, LS.xlength)
         ar .= trait
         # an array full of value InputData[i]. dims y,x
         pop_param = ar
     end
     if sd_trait != 0
-        pop_param = randomize!(pop_param,sd_trait)
+        pop_param = randomize!(pop_param, sd_trait)
     end
     return pop_param #Matrix{Float64}
 end
@@ -277,7 +259,7 @@ function get_pop_carry(
     #initialize array to save results of both ways to generate carry
     carry_arr = Matrix{Float64}(undef, LS.ylength, LS.xlength)
     # carry via metabolic_theory
-    carry_arr[:,:] = get_pop_var(
+    carry_arr[:, :] = get_pop_var(
         traits.carry,
         traits.sd_carry,
         exp_carry,
@@ -290,13 +272,13 @@ function get_pop_carry(
         E,
     )
     # is factor 100 needed? was present in old code, commented out
-    carry_arr[:,:] = @view(carry_arr[:,:,1]) .* habitat #*100
+    carry_arr[:, :] = @view(carry_arr[:, :, 1]) .* habitat #*100
     # carry via biomass_capacity
     #carry_arr[:,:,2] = mass .\ LS.biomass_capacity
     # take the minimum of either as carry for each cell
     #carry = dropdims(minimum(carry_arr, dims=3), dims=3)
-    replace!(carry_arr, NaN=>0)
-    carry = trunc.(Int,carry_arr)
+    replace!(carry_arr, NaN => 0)
+    carry = trunc.(Int, carry_arr)
     return carry
 end
 
@@ -351,14 +333,14 @@ timestep and calculates the amount of species in the next timestep.
 function reproduce!(species::Vector{Species}, Reproduction, timestep::Int)
     for sp in species
         for coordinates in sp.vars.occurrences # spatial loop
-            sp.abundances[coordinates,timestep+1] = trunc(
+            sp.abundances[coordinates, timestep + 1] = trunc(
                 Int,
                 Reproduction(
-                    sp.abundances[coordinates,timestep],
+                    sp.abundances[coordinates, timestep],
                     sp.vars.growrate[coordinates],
                     sp.vars.carry[coordinates],
                     sp.vars.bevmort[coordinates],
-                )
+                ),
             ) # Reproduction
         end
     end
@@ -377,15 +359,15 @@ Dispersal
 function Disperse!(
     species::Vector{Species},
     LS::Landscape,
-    groups::NTuple{4, Vector{Chunk}},
+    groups::NTuple{4,Vector{Chunk}},
     timestep::Int64,
 )
     for sp in species
         groupcount = 1
         # initialize offspring
         sp.vars.offspring = zeros(
-            LS.ylength+2*sp.traits.max_dispersal_dist,
-            LS.xlength+2*sp.traits.max_dispersal_dist,
+            LS.ylength + 2 * sp.traits.max_dispersal_dist,
+            LS.xlength + 2 * sp.traits.max_dispersal_dist,
         )
         # process each group of Chunks after the other concurrently
         for group in groups
@@ -433,22 +415,22 @@ TBW
 """
 function Survive!(species::Vector{Species}, DispersalSurvival, t::Int64)
     for sp in species
-        occurrences = findall(
-            (sp.vars.offspring[1:size(sp.abundances,1),1:size(sp.abundances,2)].>0)
-        )
-        occurrences = hcat(getindex.(occurrences, 1),getindex.(occurrences, 2))
-        sp.abundances[:,:,t+1] = DispersalSurvival(
-            sp.abundances[:,:,t+1],
+        occurrences = findall((
+            sp.vars.offspring[1:size(sp.abundances, 1), 1:size(sp.abundances, 2)] .> 0
+        ))
+        occurrences = hcat(getindex.(occurrences, 1), getindex.(occurrences, 2))
+        sp.abundances[:, :, t + 1] = DispersalSurvival(
+            sp.abundances[:, :, t + 1],
             sp.vars.offspring,
             occurrences,
             sp.traits.max_dispersal_dist,
         )
         # Survival to the next timestep depending on habitat quality
-        sp.abundances[:,:,t+1] = round.(
-            HabitatMortality(sp.abundances[:,:,t+1],sp.vars.future_is_habitat))
-        pos = findall(isnan.(sp.habitat[:,:,1]))
+        sp.abundances[:, :, t + 1] =
+            round.(HabitatMortality(sp.abundances[:, :, t + 1], sp.vars.future_is_habitat))
+        pos = findall(isnan.(sp.habitat[:, :, 1]))
         #sp.abundances[pos,t] = NaN
-        sp.abundances[pos,t+1] .= missing
+        sp.abundances[pos, t + 1] .= missing
     end
 end
 
@@ -477,17 +459,16 @@ function disperse_chunk!(
         #cache values (mostly a makes the code more readable)
         y, x = coordinates[1], coordinates[2]
         #check if x,y is in a given chunk
-        if y >= chunk.y && y < chunk.y+(species.traits.max_dispersal_buffer*2) && x >= chunk.x && x < chunk.x+(species.traits.max_dispersal_buffer*2) #TODO: rewrite this condition
-        # Dispersal (Race conditions in SD.Offspring averted by separating landscape into disjunct chunks)
-            offspring[
-                y:(y+species.traits.max_dispersal_buffer),
-                x:(x+species.traits.max_dispersal_buffer),
-            ] =
-            KernelDispersal!(
-                species.abundances[y,x,t+1], #N
+        if y >= chunk.y &&
+            y < chunk.y + (species.traits.max_dispersal_buffer * 2) &&
+            x >= chunk.x &&
+            x < chunk.x + (species.traits.max_dispersal_buffer * 2) #TODO: rewrite this condition
+            # Dispersal (Race conditions in SD.Offspring averted by separating landscape into disjunct chunks)
+            offspring[y:(y + species.traits.max_dispersal_buffer), x:(x + species.traits.max_dispersal_buffer)] = KernelDispersal!(
+                species.abundances[y, x, t + 1], #N
                 offspring[ #number offspring
-                    y:(y+species.traits.max_dispersal_buffer),
-                    x:(x+species.traits.max_dispersal_buffer),
+                    y:(y + species.traits.max_dispersal_buffer),
+                    x:(x + species.traits.max_dispersal_buffer),
                 ],
                 species.dispersal_kernel, #Kernel
             )
@@ -503,25 +484,22 @@ end
 
 Calculate the distinct chunk groups
 """
-function GetDisjunctChunkGroups(
-    max_dispersal_buffer::Int64,
-    size::Tuple{Int64, Int64, Int64},
-)
+function GetDisjunctChunkGroups(max_dispersal_buffer::Int64, size::Tuple{Int64,Int64,Int64})
     #separate landscape into 4 disjunct chunk groups
     #Each chunk has the size (2*Dispersalbuffer x 2*Dispersalbuffer)
     #This is to ensure that disjunct groups of roughly equal size can be made trivially
     group1, group2, group3, group4 = Chunk[], Chunk[], Chunk[], Chunk[]
 
-    for x in 1:max_dispersal_buffer*2:size[2]
-        for y in 1:max_dispersal_buffer*2:size[1]
-            if x % (max_dispersal_buffer*4) - 1 == 0
-                if y % (max_dispersal_buffer*4) - 1 == 0
+    for x in 1:(max_dispersal_buffer * 2):size[2]
+        for y in 1:(max_dispersal_buffer * 2):size[1]
+            if x % (max_dispersal_buffer * 4) - 1 == 0
+                if y % (max_dispersal_buffer * 4) - 1 == 0
                     push!(group1, Chunk(x, y))
                 else
                     push!(group2, Chunk(x, y))
                 end
             else
-                if y % (max_dispersal_buffer*4) - 1 == 0
+                if y % (max_dispersal_buffer * 4) - 1 == 0
                     push!(group3, Chunk(x, y))
                 else
                     push!(group4, Chunk(x, y))

--- a/src/initialization_functions.jl
+++ b/src/initialization_functions.jl
@@ -570,8 +570,9 @@ function read_ts_config(env_dir::String, ls_timeseries_config::String)
         ls_timeseries_config = "default"
     end
     if ls_timeseries_config != "default"
-        input_ts_config =
-            Dict{String,Int}(CSV.File(joinpath(env_dir, ls_timeseries_config)))
+        input_ts_config = Dict{String,Int}(
+            CSV.File(joinpath(env_dir, ls_timeseries_config))
+        )
         #Overwrite defaults where applicable
         for key in keys(input_ts_config)
             ts_config[key] = input_ts_config[key]

--- a/src/initialization_functions.jl
+++ b/src/initialization_functions.jl
@@ -6,10 +6,11 @@ function ParamCalibration(
     mass::Float64,
     reference_temp::Float64,
     E::Float64,
-    )
+)
     #we divide here because the numbers become too high to handle for some systems otherwise
     #honestly not a fan of magic numbers, could this be fixed in another way? - R
-    param_const = parameter/((mass^(exponent))*exp(-E/(k * reference_temp)))/500000000000
+    param_const =
+        parameter / ((mass^(exponent)) * exp(-E / (k * reference_temp))) / 500000000000
     return param_const
 end
 
@@ -18,26 +19,27 @@ function MetabolicRate(
     param_const::Float64,
     exponent::Float64,
     mass::Array{Float64,2},
-    temperature::SubArray{Float64, 2, Array{Float64, 3}},
-    E::Float64)
-  # bodymass dependent - demographic
-  Mass1 = mass.^(exponent)
-  # temperature dependent - environment)
-  T1 = exp.(-E./(k.*temperature))
-  ## we multiply here because we divided by this factor earlier
-  modified_parameter = param_const.*Mass1.*T1.*500000000000
-  return modified_parameter
+    temperature::SubArray{Float64,2,Array{Float64,3}},
+    E::Float64,
+)
+    # bodymass dependent - demographic
+    Mass1 = mass .^ (exponent)
+    # temperature dependent - environment)
+    T1 = exp.(-E ./ (k .* temperature))
+    ## we multiply here because we divided by this factor earlier
+    modified_parameter = param_const .* Mass1 .* T1 .* 500000000000
+    return modified_parameter
 end
 
 ### TODO re-write this as calculation of habitat suitability, not tolerance
 function get_habitat_suit(vmax, vopt, vmin, venv)
-  left = ((vmax.-venv)./(vmax-vopt))
-  right = ((venv.-vmin)/(vopt-vmin))
-  right[right.<0] .= 0
-  ex = ((vopt-vmin)/(vmax-vopt))
-  res = left.*right.^ex
-  res[res.<0] .= 0
-  return res
+    left = ((vmax .- venv) ./ (vmax - vopt))
+    right = ((venv .- vmin) / (vopt - vmin))
+    right[right .< 0] .= 0
+    ex = ((vopt - vmin) / (vmax - vopt))
+    res = left .* right .^ ex
+    res[res .< 0] .= 0
+    return res
 end
 
 """
@@ -49,31 +51,26 @@ end
 Initialization of Abundances.
 """
 function InitializeAbundances(
-    SP::Simulation_Parameters,
-    habitat::Array{Float64, 2},
-    carry::Float64
+    SP::Simulation_Parameters, habitat::Array{Float64,2}, carry::Float64
 )
     abundances = zeros(Int, size(habitat)[1], size(habitat)[2], SP.timesteps) # x y z
-        if SP.initialize_cells == "all"
-            abundances[:,:,1] = round.(
-                Int,
-                rand(0:carry/10,size(habitat)[1],
-                size(habitat)[2])
-            )
-            pos = findall(isnan.(habitat))
-            zusatz = zeros(size(habitat))
-            zusatz[:,:] = abundances[:,:,1]
-            zusatz[pos] .= 0
-            abundances[:,:,1] = zusatz
+    if SP.initialize_cells == "all"
+        abundances[:, :, 1] =
+            round.(Int, rand(0:(carry / 10), size(habitat)[1], size(habitat)[2]))
+        pos = findall(isnan.(habitat))
+        zusatz = zeros(size(habitat))
+        zusatz[:, :] = abundances[:, :, 1]
+        zusatz[pos] .= 0
+        abundances[:, :, 1] = zusatz
 
     elseif SP.initialize_cells == "habitat"
         zusatz = zeros(size(habitat))
         pos = findall(isnan.(habitat))
         #println("nans in habitat:")
         #println(pos)
-        zusatz[:,:] = habitat[:,:]
+        zusatz[:, :] = habitat[:, :]
         zusatz[pos] .= 0
-        abundances[:,:,1] = round.(Int, carry.*zusatz)
+        abundances[:, :, 1] = round.(Int, carry .* zusatz)
         #println("zeros in abundances:")
         #findall(abundances[:,:,1].==0)
     end
@@ -93,8 +90,8 @@ function randomize!(value, sd)
         end
     elseif isa(value, Float64)
         if sd != 0 && value > 0 #additional check for sd != 0 because change otherwise
-            mu = log(value^2 /sqrt((sd^2)+(value^2)))
-            sig = sqrt(log(1 +((sd^2)/(value^2))))
+            mu = log(value^2 / sqrt((sd^2) + (value^2)))
+            sig = sqrt(log(1 + ((sd^2) / (value^2))))
             value = rand(LogNormal(mu, sig))
         end
     end
@@ -103,33 +100,33 @@ end
 
 ## Performs Sanity Check on constants
 function check_constants()
-  # TODO implement this
+    # TODO implement this
 end
 
 ## functions to parse strings in dicts to julia datatypes
 
 # Convert all string formatted numeric arguments to julia numeric types
 function parse_fields_numeric!(dict::Dict)
-  for key in keys(dict)
-    parsed = tryparse(Int, dict[key])
-    if !isnothing(parsed)
-      dict[key] = parsed
-    else
-      parsed = tryparse(Float64, dict[key])
-      if !isnothing(parsed)
-        dict[key] = parsed
-      end
+    for key in keys(dict)
+        parsed = tryparse(Int, dict[key])
+        if !isnothing(parsed)
+            dict[key] = parsed
+        else
+            parsed = tryparse(Float64, dict[key])
+            if !isnothing(parsed)
+                dict[key] = parsed
+            end
+        end
     end
-  end
 end
 
 # Convert all boolean arguments to actual Julia booleans
 function parse_fields_bool!(dict::Dict)
-  for key in keys(dict::Dict)
-    if dict[key] == "false" || dict[key] == "true"
-      dict[key] = dict[key] == "true" ? true : false
+    for key in keys(dict::Dict)
+        if dict[key] == "false" || dict[key] == "true"
+            dict[key] = dict[key] == "true" ? true : false
+        end
     end
-  end
 end
 
 """
@@ -139,15 +136,15 @@ Convert all Float and Integer arguments to their respective Julia types (as need
 the species)
 """
 function parse_species_datatypes!(species::Dict)
-  for key in keys(species)
-    parsed = tryparse(Float64, species[key])
-    if !isnothing(parsed)
-      species[key] = parsed
+    for key in keys(species)
+        parsed = tryparse(Float64, species[key])
+        if !isnothing(parsed)
+            species[key] = parsed
+        end
     end
-  end
-  for key in ("max_dispersal_dist","mean_dispersal_dist")
-    species[key] = floor(Int, species[key])
-  end
+    for key in ("max_dispersal_dist", "mean_dispersal_dist")
+        species[key] = floor(Int, species[key])
+    end
 end
 
 """
@@ -158,8 +155,7 @@ Build the Dicts containing environment attribute and restriction files.
 function parse_environment_parameters!(config::Dict, input_config::Dict)
     # 1. get the environment parameters (defined as all "unexpected" keys!)
     env_parameters = filter(
-        x -> x ∉ keys(get_default_simulation_parameters()),
-        keys(input_config)
+        x -> x ∉ keys(get_default_simulation_parameters()), keys(input_config)
     )
     # 2. divide the parameters into the environment attributes and restrictions
     env_attributes = filter(x -> !occursin("restriction", x), env_parameters)
@@ -169,19 +165,19 @@ function parse_environment_parameters!(config::Dict, input_config::Dict)
     env_restriction_files = Dict{String,String}()
     #print environmental attributes and set in dictionary
     for key in env_attributes
-      println(key)
-      env_attribute_files[key] = input_config[key]
+        println(key)
+        env_attribute_files[key] = input_config[key]
     end
     for key in env_restrictions
-      env_restriction_files[key] = input_config[key]
+        env_restriction_files[key] = input_config[key]
     end
     #check if any environment attribute files have been defined
     if isempty(env_attribute_files)
-      throw(UndefVarError("No environment attribute (i.e. precipitation) was given"))
+        throw(UndefVarError("No environment attribute (i.e. precipitation) was given"))
     end
     #update dictionary
     config["env_attribute_files"] = env_attribute_files
-    config["env_restriction_files"] = env_restriction_files
+    return config["env_restriction_files"] = env_restriction_files
 end
 
 ## auxillary functions for the reading of simulation parameters (configuration.csv)
@@ -199,8 +195,8 @@ function check_speciesdir!(config::Dict, config_path::String)
                     "\"species\" directory is missing in the configuration input folder!\n",
                     "Please provide either a \"species\" directory at \"$config_path\" or ",
                     "provide a custom path to a directory with species data with a ",
-                    "\"species_dir\" argument in \"configuration.csv\"!"
-                )
+                    "\"species_dir\" argument in \"configuration.csv\"!",
+                ),
             )
         end
         #TODO Except empty species dir
@@ -209,8 +205,8 @@ function check_speciesdir!(config::Dict, config_path::String)
             throw(
                 string(
                     "The specified species directory at $(config["species_dir"]) ",
-                    "does not exist!"
-                )
+                    "does not exist!",
+                ),
             )
         end
     end
@@ -233,16 +229,17 @@ function check_environmentdir!(config::Dict, config_path::String)
                     "\"$config_path\" or provide a custom path to a directory with ",
                     "environment data with an \"environment_dir\" argument in ",
                     "\"configuration.csv\"!",
-                )
+                ),
             )
         end
     else
         if !isdir(config["environment_dir"])
             throw(
-                string("The specified environment directory at \"",
-                config["environment_dirraw"],
-                "\" does not exist!"
-                )
+                string(
+                    "The specified environment directory at \"",
+                    config["environment_dirraw"],
+                    "\" does not exist!",
+                ),
             )
         end
     end
@@ -256,16 +253,16 @@ Check if necessary configuration fields are missing
 function sp_sanity_checks!(config::Dict)
     for key in keys(config)
         if isnothing(config[key])
-            throw("Argument \""*key*"\" is missing in configuration.csv!")
+            throw("Argument \"" * key * "\" is missing in configuration.csv!")
         end
     end
     # Sanity Checks
     if config["timesteps"] < 1
-        throw("\"timesteps\" is "*config["timesteps"]*", it has to be larger than 1!")
+        throw("\"timesteps\" is " * config["timesteps"] * ", it has to be larger than 1!")
     end
     if !ispath(config["output_dir"])
         mkpath(config["output_dir"])
-        @info("Output directory created at: ",config["output_dir"])
+        @info("Output directory created at: ", config["output_dir"])
     end
     #normalize path formatting
     if !endswith(config["output_dir"], "/")
@@ -277,7 +274,7 @@ function sp_sanity_checks!(config::Dict)
     if !endswith(config["environment_dir"], "/")
         config["environment_dir"] = config["environment_dir"] * "/"
     end
-#TODO check if invasion boundaries are within landsape
+    #TODO check if invasion boundaries are within landsape
 end
 
 ## auxillary functions for the reading of landscape parameters (environment folder)
@@ -310,48 +307,48 @@ function check_attribute_values!(attribute::Array{Float64}, key::String)
                     "Mean of input temperature seems to be too high to assume Celsius ",
                     "values and too low to assume Kelvin values.\n Results will likely ",
                     "make no sense. Unless you're trying to simulate alien life, please ",
-                    "check your input!"
+                    "check your input!",
                 )
             )
         elseif meantemp < 360
             @info("Temperature input values are assumed to be in Kelvin.")
         else
-        @warn(
-            string(
-                "Input temperatures seem unusually high with a mean temperature of ",
-                meantemp,
-                ", please make sure to check your input."
-            )
-        )
-    end
-    if any(x->x<=0, attribute)
-        throw(
-            string(
-                "Temperature below 0 Kelvin detected, something is wrong with the ",
-                "provided temperature data!"
-            )
-        )
-    end
-    elseif key == "precipitation"
-    # special checks for environment attribute precipitation
-        if any(x->x<=0, attribute)
-            throw(
+            @warn(
                 string(
-                    "Precipitation below 0 detected, something is wrong with the provided ",
-                    "precipitation data!"
+                    "Input temperatures seem unusually high with a mean temperature of ",
+                    meantemp,
+                    ", please make sure to check your input.",
                 )
             )
         end
-    #Implement further sanity checks as needed!
+        if any(x -> x <= 0, attribute)
+            throw(
+                string(
+                    "Temperature below 0 Kelvin detected, something is wrong with the ",
+                    "provided temperature data!",
+                ),
+            )
+        end
+    elseif key == "precipitation"
+        # special checks for environment attribute precipitation
+        if any(x -> x <= 0, attribute)
+            throw(
+                string(
+                    "Precipitation below 0 detected, something is wrong with the provided ",
+                    "precipitation data!",
+                ),
+            )
+        end
+        #Implement further sanity checks as needed!
     end
 end
 
 function check_restriction_values!(restriction::Array{Float64}, key::String)
-  #TODO Sanity checks on restriction values
-  x = 1 #dummy
+    #TODO Sanity checks on restriction values
+    return x = 1 #dummy
 end
 
-function read_env_para_dir(env_dir::String, dir::String,key::String)
+function read_env_para_dir(env_dir::String, dir::String, key::String)
     param_dir = joinpath(env_dir, dir)
     param_files = sort_dir(readdir(param_dir))
     if isempty(param_files)
@@ -359,16 +356,13 @@ function read_env_para_dir(env_dir::String, dir::String,key::String)
     end
     # read first timestep to get the required dimensions for the matrix
     param_init = readdlm(joinpath(param_dir, param_files[1]), ' ', Float64)
-    parameter = Array{Float64, 3}(
-      undef,
-      size(param_init)[1],
-      size(param_init)[2],
-      length(param_files),
-      )
+    parameter = Array{Float64,3}(
+        undef, size(param_init)[1], size(param_init)[2], length(param_files)
+    )
     # optimization: save the matrix used to get the dimensions into the first timestep
-    parameter[:,:,1] = param_init
+    parameter[:, :, 1] = param_init
     for i in 2:length(param_files)
-      parameter[:,:,i] = readdlm(joinpath(param_dir, param_files[i]), ' ', Float64)
+        parameter[:, :, i] = readdlm(joinpath(param_dir, param_files[i]), ' ', Float64)
     end
     return parameter
 end
@@ -376,24 +370,20 @@ end
 function sort_dir(x::Vector{String})
     f = text -> all(isnumeric, text) ? Char(parse(Int, text)) : text
     sorter = key -> join(f(m.match) for m in eachmatch(r"[0-9]+|[^0-9]+", key))
-    return sort(x, by=sorter)
+    return sort(x; by=sorter)
 end
 ## turns 2-dimensional landscape into 3 if only one input timestep is given
 function CreateTimeseries(
-    landscape::Matrix{Float64},
-    prediction,
-    sd,
-    change_onset,
-    timesteps::Int64,
+    landscape::Matrix{Float64}, prediction, sd, change_onset, timesteps::Int64
 )
-  # check landscape #######
-    if !isa(landscape,Array)
+    # check landscape #######
+    if !isa(landscape, Array)
         throw("landscape is not array or does not exist")
     end
     if any(isnan.(landscape))
         println("landscape contains NA")
     end
-    if isa(prediction,Array)
+    if isa(prediction, Array)
         if any(isnan.(prediction))
             println("prediction contains NA")
         end
@@ -417,22 +407,23 @@ function CreateTimeseries(
         #stop()
     end
     # start of creation #######
-    res = Array{Float64}(undef,size(landscape)[1], size(landscape)[2], timesteps)
-    res[:,:,1] = landscape
+    res = Array{Float64}(undef, size(landscape)[1], size(landscape)[2], timesteps)
+    res[:, :, 1] = landscape
     if change_onset >= 2 && change_onset <= timesteps
-        if isa(prediction,Array)
-            res[:,:,timesteps] = prediction
+        if isa(prediction, Array)
+            res[:, :, timesteps] = prediction
         else
-            res[:,:,timesteps] = res[:,:,1] .+ prediction
-      end
-      res[:,:,change_onset] = res[:,:,1]
-      res = lerp(res) # lerp is in landscape_functions
+            res[:, :, timesteps] = res[:, :, 1] .+ prediction
+        end
+        res[:, :, change_onset] = res[:, :, 1]
+        res = lerp(res) # lerp is in landscape_functions
     else
-        res[:,:,:] .= res[:,:,1]
+        res[:, :, :] .= res[:, :, 1]
     end
     if sd > 0
-        res[:,:,:] .= TempFluctuation(dim(landscape)[1], dim(landscape)[2],
-            timesteps, sd, res)
+        res[:, :, :] .= TempFluctuation(
+            dim(landscape)[1], dim(landscape)[2], timesteps, sd, res
+        )
     end
     return res
 end
@@ -444,79 +435,79 @@ function read_ls(
     env_restr::Dict{String,String},
     timesteps::Int,
 )
-    environment = Dict{String, Array{Float64, 3}}()
+    environment = Dict{String,Array{Float64,3}}()
     # read environment attributes
     for key in keys(env_attib)
-      attribute = Nothing
-      # If a single file is given, read it and create a timeseries of required length
-      if isfile(joinpath(env_dir, env_attib[key]))
-        attribute = readdlm(joinpath(env_dir, env_attib[key]), ' ', Float64)
-        # Generate timeseries data
-        attribute = CreateTimeseries(attribute,0,0,0,timesteps)
-      # If a directory is given, read its content as a fileseries
-      elseif ispath(joinpath(env_dir, env_attib[key]))
-        attribute = read_env_para_dir(env_dir, env_attib[key], key)
-      else
-        throw(
-            string(
-                "$key file or directory $(env_attib[key]), does not exist at specified ",
-                "environment data location: $env_dir",
+        attribute = Nothing
+        # If a single file is given, read it and create a timeseries of required length
+        if isfile(joinpath(env_dir, env_attib[key]))
+            attribute = readdlm(joinpath(env_dir, env_attib[key]), ' ', Float64)
+            # Generate timeseries data
+            attribute = CreateTimeseries(attribute, 0, 0, 0, timesteps)
+            # If a directory is given, read its content as a fileseries
+        elseif ispath(joinpath(env_dir, env_attib[key]))
+            attribute = read_env_para_dir(env_dir, env_attib[key], key)
+        else
+            throw(
+                string(
+                    "$key file or directory $(env_attib[key]), does not exist at specified ",
+                    "environment data location: $env_dir",
+                ),
             )
-        )
-      end
-      # sanity checks
-      #check_for_nan(attribute)
-      check_attribute_values!(attribute, key)
+        end
+        # sanity checks
+        #check_for_nan(attribute)
+        check_attribute_values!(attribute, key)
 
-      environment[key] = attribute
+        environment[key] = attribute
     end
     # read environment restrictions
-    restrictions = Dict{String, Array{Float64, 3}}()
+    restrictions = Dict{String,Array{Float64,3}}()
     for key in keys(env_restr)
-      restriction = Nothing
-      # check for existance of file and read file
-      if isfile(joinpath(env_dir, env_restr[key]))
-        restriction = readdlm(joinpath(env_dir, env_restr[key]), ' ', Float64)
-        # Generate timeseries data
-        restriction = CreateTimeseries(restriction,0,0,0,timesteps)
-      elseif ispath(joinpath(env_dir, env_restr[key]))
-        restriction = read_env_para_dir(env_dir, env_restr[key], key)
-      else
-        throw(
-            string(
-                "$key file or directory $(env_restr[key]), does not exist at specified ",
-                "environment data location: $env_dir",
+        restriction = Nothing
+        # check for existance of file and read file
+        if isfile(joinpath(env_dir, env_restr[key]))
+            restriction = readdlm(joinpath(env_dir, env_restr[key]), ' ', Float64)
+            # Generate timeseries data
+            restriction = CreateTimeseries(restriction, 0, 0, 0, timesteps)
+        elseif ispath(joinpath(env_dir, env_restr[key]))
+            restriction = read_env_para_dir(env_dir, env_restr[key], key)
+        else
+            throw(
+                string(
+                    "$key file or directory $(env_restr[key]), does not exist at specified ",
+                    "environment data location: $env_dir",
+                ),
             )
-        )
-      end
-      # sanity checks
-      #check_for_nan(restriction)
-      #check_restriction_values!(restriction, key)
+        end
+        # sanity checks
+        #check_for_nan(restriction)
+        #check_restriction_values!(restriction, key)
 
-      restrictions[key] = restriction
+        restrictions[key] = restriction
     end
 
     # check if sizes of all inputs match
-    all_properties = merge(environment,restrictions)
+    all_properties = merge(environment, restrictions)
     landscape_size = size(environment[collect(keys(all_properties))[1]])[1:2]
     if any(k -> size(k[2])[1:2] != landscape_size, all_properties)
         sizes = ""
         for key in keys(all_properties)
-          sizes = string(
-              sizes,
-              "$key: (",
-              string(size(all_properties[key])[1]),
-              ",",
-              string(size(all_properties[key])[2]),
-              ") \n",
-          )
+            sizes = string(
+                sizes,
+                "$key: (",
+                string(size(all_properties[key])[1]),
+                ",",
+                string(size(all_properties[key])[2]),
+                ") \n",
+            )
         end
         throw(
             string(
                 "Size mismatch in dimensions of provided environment data, please make ",
                 "sure that they match in all dimensions! \n",
                 sizes,
-            )
+            ),
         )
     end
 
@@ -525,11 +516,11 @@ function read_ls(
         filter!(k -> size(k[2])[3] < timesteps, all_properties)
         durations = ""
         for key in keys(all_properties)
-          durations = string(
-            "$durations Timesteps given with $key: ",
-            string(size(all_properties["key"])[3]),
-            "\n",
-        )
+            durations = string(
+                "$durations Timesteps given with $key: ",
+                string(size(all_properties["key"])[3]),
+                "\n",
+            )
         end
         throw(
             string(
@@ -537,21 +528,18 @@ function read_ls(
                 "$timesteps. Please make sure that for each landscape properties at least ",
                 "the minimum required simulation timesteps are provided! \n",
                 durations,
-            )
+            ),
         )
     end
 
     # process restrictions
     if isempty(restrictions)
-        restrictions = Array{Float64, 3}(
-            undef,
-            landscape_size[1],
-            landscape_size[2],
-            timesteps
+        restrictions = Array{Float64,3}(
+            undef, landscape_size[1], landscape_size[2], timesteps
         )
         fill!(restrictions, 1)
     else
-      #TODO implement blending of multiple restriction types
+        #TODO implement blending of multiple restriction types
         restrictions = restrictions[collect(keys(restrictions))[1]]
     end
 
@@ -570,45 +558,45 @@ end
 Returns the timeseries generator configuration as a Dict (no struct as it's only used once)
 """
 function read_ts_config(env_dir::String, ls_timeseries_config::String)
-  ts_config = get_default_ls_timeseries_config()
-  if !isfile(joinpath(env_dir, ls_timeseries_config)) && ls_timeseries_config != "default"
-    warn(
-        string(
-            "Ls_timeseries_config file $ls_timeseries_config does not exist at specified ",
-            "environment data location: $env_dir \n",
-            "Falling back to default values!",
+    ts_config = get_default_ls_timeseries_config()
+    if !isfile(joinpath(env_dir, ls_timeseries_config)) && ls_timeseries_config != "default"
+        warn(
+            string(
+                "Ls_timeseries_config file $ls_timeseries_config does not exist at specified ",
+                "environment data location: $env_dir \n",
+                "Falling back to default values!",
+            ),
         )
-    )
-    ls_timeseries_config = "default"
-  end
-  if ls_timeseries_config != "default"
-    input_ts_config = CSV.File(joinpath(env_dir, ls_timeseries_config)) |> Dict{String, Int}
-    #Overwrite defaults where applicable
-    for key in keys(input_ts_config)
-      ts_config[key] = input_ts_config[key]
+        ls_timeseries_config = "default"
     end
-  end
-  return ts_config
+    if ls_timeseries_config != "default"
+        input_ts_config =
+            Dict{String,Int}(CSV.File(joinpath(env_dir, ls_timeseries_config)))
+        #Overwrite defaults where applicable
+        for key in keys(input_ts_config)
+            ts_config[key] = input_ts_config[key]
+        end
+    end
+    return ts_config
 end
 
 function init_out_dir(SP::Simulation_Parameters)
     out_dir = joinpath(
         SP.output_dir,
-        string(SP.experiment_name,Dates.format(now()," at dd.mm.yyyy HH-MM-SS")),
+        string(SP.experiment_name, Dates.format(now(), " at dd.mm.yyyy HH-MM-SS")),
     )
     mkdir(out_dir)
     if SP.input_backup
         backup_dir = joinpath(out_dir, "input")
         cp(SP.config_dir, backup_dir)
         configfile = joinpath(backup_dir, "configuration.csv")
-        df = CSV.File(configfile)  |> DataFrame
-        config = CSV.File(configfile)  |> Dict{String, Any}
+        df = DataFrame(CSV.File(configfile))
+        config = Dict{String,Any}(CSV.File(configfile))
         config["species_dir"] = replace(joinpath(backup_dir, "species"), "\\" => "/")
         config["environment_dir"] = replace(
-            joinpath(backup_dir, "environment"),
-            "\\" => "/"
+            joinpath(backup_dir, "environment"), "\\" => "/"
         )
-        df.Value = map(akey->config[akey], df.Argument)
-        CSV.write(configfile, df, delim=" ")
+        df.Value = map(akey -> config[akey], df.Argument)
+        CSV.write(configfile, df; delim=" ")
     end
 end

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -1,19 +1,34 @@
 using Plots
-plot1 = heatmap(reverse(SD.species[1].abundances[:,:,1],dims=1), title = "Abundance at start")
-plot2 = heatmap(reverse(SD.species[1].abundances[:,:,SD.parameters.timesteps],dims=1), title = "Abundance at end")
-plot(plot1,plot2, layout = (1,2))
+plot1 = heatmap(
+    reverse(SD.species[1].abundances[:, :, 1]; dims=1); title="Abundance at start"
+)
+plot2 = heatmap(
+    reverse(SD.species[1].abundances[:, :, SD.parameters.timesteps]; dims=1);
+    title="Abundance at end",
+)
+plot(plot1, plot2; layout=(1, 2))
 
-plot4 = heatmap(reverse(SD.landscape.environment["temperature"][:,:,1],dims=1), title="Temperature")
-plot5 = heatmap(reverse(SD.landscape.environment["precipitation"][:,:,1],dims=1), title="Precipitation")
-plot(plot4, plot5, layout = (1,2))
+plot4 = heatmap(
+    reverse(SD.landscape.environment["temperature"][:, :, 1]; dims=1); title="Temperature"
+)
+plot5 = heatmap(
+    reverse(SD.landscape.environment["precipitation"][:, :, 1]; dims=1);
+    title="Precipitation",
+)
+plot(plot4, plot5; layout=(1, 2))
 
-plot5 = heatmap(reverse(SD.species[1].vars.habitat,dims=1), title="Habitat suitability")
+plot5 = heatmap(reverse(SD.species[1].vars.habitat; dims=1); title="Habitat suitability")
 plot(plot5)
-plot6 = heatmap(reverse(SD.species[1].habitat[:,:,1],dims=1), title="Habitat suitability at start")
-plot7 = heatmap(reverse(SD.species[1].habitat[:,:,(SD.parameters.timesteps-1)],dims=1), title="Habitat suitability at end")
+plot6 = heatmap(
+    reverse(SD.species[1].habitat[:, :, 1]; dims=1); title="Habitat suitability at start"
+)
+plot7 = heatmap(
+    reverse(SD.species[1].habitat[:, :, (SD.parameters.timesteps - 1)]; dims=1);
+    title="Habitat suitability at end",
+)
 
 ### ok now let's try CairoMakie shall we?
 using CairoMakie
 
-heatmap(rotr90(SD.species[1].abundances[:,:,10]))
-heatmap(rotr90(SD.species[1].habitat[:,:,10]))
+heatmap(rotr90(SD.species[1].abundances[:, :, 10]))
+heatmap(rotr90(SD.species[1].habitat[:, :, 10]))

--- a/test/defaults.jl
+++ b/test/defaults.jl
@@ -1,9 +1,9 @@
 @testset "defaults" begin
     @testset "get_default_ls_timeseries_config" begin
-    c = MetaRange.get_default_ls_timeseries_config()
-    @test c isa Dict{String, Any}
-    @test c["prediction"] == 0
-    @test c["change_onset"] == 0
-    @test c["sd"] == 0
+        c = MetaRange.get_default_ls_timeseries_config()
+        @test c isa Dict{String,Any}
+        @test c["prediction"] == 0
+        @test c["change_onset"] == 0
+        @test c["sd"] == 0
     end
 end

--- a/test/eco_functions.jl
+++ b/test/eco_functions.jl
@@ -4,7 +4,7 @@
         Ns = rand(1:100000, 10)
         g = rand(0.01:0.01:10.0, 10)
         c = rand(0.0:0.01:100000.0, 10)
-        param = [(Ns[i], g[i], c[i], nothing) for i=1:10]
+        param = [(Ns[i], g[i], c[i], nothing) for i in 1:10]
         @testset "Ricker" begin
             @testset "known cases" begin
                 @test MetaRange.ReproductionRicker(100, 1.0, 100.0, nothing) == 100

--- a/test/eco_loop_functions.jl
+++ b/test/eco_loop_functions.jl
@@ -6,7 +6,8 @@
     @testset "GetReproductionModel" begin
         @test MetaRange.GetReproductionModel("Ricker") == MetaRange.ReproductionRicker
         @test MetaRange.GetReproductionModel("Beverton") == MetaRange.BV
-        @test MetaRange.GetReproductionModel("RickerAllee") == MetaRange.ReproductionRickerAllee
+        @test MetaRange.GetReproductionModel("RickerAllee") ==
+            MetaRange.ReproductionRickerAllee
         @test_throws ArgumentError MetaRange.GetReproductionModel("foo")
     end
 end

--- a/test/initialization_functions.jl
+++ b/test/initialization_functions.jl
@@ -3,7 +3,7 @@
         Random.seed!(10)
         @testset "standard deviation" begin
             @test MetaRange.randomize!(10.0, 0.0) == 10.0
-            @test MetaRange.randomize!(10.0, 0.0001) ≈ 10.0 rtol=1e-4
+            @test MetaRange.randomize!(10.0, 0.0001) ≈ 10.0 rtol = 1e-4
             m = fill(10.0, (10, 10))
             @test MetaRange.randomize!(m, 0.0) == fill(10.0, (10, 10))
             @test MetaRange.randomize!(m, 0.1) != fill(10.0, (10, 10))

--- a/test/read_input.jl
+++ b/test/read_input.jl
@@ -1,6 +1,6 @@
 @testset "read_input.jl" begin
     @testset "ParamCalibration" begin
-        @test MetaRange.ParamCalibration(0.0 , 1.0, 1.0, 297.0, 0.65) == 0
+        @test MetaRange.ParamCalibration(0.0, 1.0, 1.0, 297.0, 0.65) == 0
         #test that if exponent == 1.0 mass has no effect
         p = MetaRange.ParamCalibration(1.0, 1.0, 1.0, 297.0, 0.65)
         @test p == MetaRange.ParamCalibration(1.0, 10.0, 1.0, 297.0, 0.65)


### PR DESCRIPTION
Closes #22

I used JuliaFormatter with the BlueStyle to autoformat the code to adhere to the Blue style guide. To do this I first installed the `JuliaFormatter` package on my Julia environment with:

```
julia -e 'using Pkg; Pkg.add("JuliaFormatter")'
```

which you only need to run once per environment and then to modify the files in-place I run:

```
julia -e 'using JuliaFormatter; format(".", BlueStyle(), overwrite=true)'
```

from within the root of the repository. JuliaFormatter will then traverse the directory structure and modify in-place (`overwrite=true`) all `.jl` files using the Blue Style (it also supports the [YAS and SciML style guides](https://docs.juliahub.com/JuliaFormatter/OWZnm/1.0.35/)). If any files change you then need to commit and push to the remote repo. Please note that in some cases you need to run the formatter more than once. You will know that you are done when no more files change.

**Note:** Other code formatters (like, for example, [black](https://black.readthedocs.io/en/stable/faq.html#is-black-safe-to-use) for Python) specifically mention that they are safe to use, because they only do stylistic formatting and ensure that the bytecode remains the same. I couldn't find such a statement for JuliaFormatter but I checked the modifications and could not find something that looks off. However, please also check the files that have been changed to ensure that everything looks the same and the code produces the same results. For example, something that caught my attention is the change in line 585 in  [src/initialization_functions.jl](https://github.com/janablechschmidt/MetaRange.jl/pull/34/files#diff-b632304f36fbae5787d9541a22c5acb144aad6f52b0f52da3bdffae52c243901) where this code:

```
input_ts_config = CSV.File(joinpath(env_dir, ls_timeseries_config)) |> Dict{String, Int}
```

changed to:

```
input_ts_config =
            Dict{String,Int}(CSV.File(joinpath(env_dir, ls_timeseries_config)))
```

From what I understand, JuliaFormatter with the Blue Style sets the [pipe_to_function_call](https://github.com/domluna/JuliaFormatter.jl#pipe_to_function_call) option to true and thus things like `x |> f` are rewritten to `f(x)`.