### PR TITLE
Use joinpath() instead of concatenation

### DIFF
--- a/src/initialization_functions.jl
+++ b/src/initialization_functions.jl
@@ -188,7 +188,7 @@ Check if species directory was given and apply default path if not
 """
 function check_speciesdir!(config::Dict, config_path::String)
     if isnothing(config["species_dir"])
-        config["species_dir"] = config_path * "species/"
+        config["species_dir"] = joinpath(config_path, "species/")
         if !isdir(config["species_dir"])
             throw(
                 string(
@@ -219,7 +219,7 @@ Check if environment directory was given and apply default path if not.
 """
 function check_environmentdir!(config::Dict, config_path::String)
     if isnothing(config["environment_dir"])
-        config["environment_dir"] = config_path * "environment/"
+        config["environment_dir"] = joinpath(config_path, "environment/")
         if !isdir(config["environment_dir"])
             throw(
                 string(


### PR DESCRIPTION
Calling `read_input(path)` with a `path` that doesn't end with a `/` produces invalid `config["species_dir"]` and `config["environment_dir"]` directories. If, for example, `path` is `path/to/MetaRange.jl/examples/static` then:

```
config["species_dir"] = path/to/MetaRange.jl/examples/staticspecies/
config["environment_dir"] = path/to/MetaRange.jl/examples/staticenvironment/
```

instead of the correct:

```
config["species_dir"] = path/to/MetaRange.jl/examples/static/species/
config["environment_dir"] = path/to/MetaRange.jl/examples/static/environment/
```

`joinpath()` is smart enough to create the correct path, whether `path` ends in `/` or not.
