### PR TITLE
Minor fixes in docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ MetaRange has been tested on Julia 1.6 and upwards on Windows and Linux.
 
 ## Usage
 
-MetaRange works by first creating a simulation struct and then calling the function `run_simulation!()` on the object. There are two main functions to execute a simulation. First, your input must be read and initialized with the `read_input()` function. This function will create a SimulationData struct, typically named SD (but you can name it whatever you want), which contains all input data as well as the structures that will hold the results, but are empty initially. SD can then be given to the function `run_simulation(SD)`, which will modify it to include the simulation results.  
+MetaRange works by first creating a simulation struct and then calling the function `run_simulation!()` on the object. There are two main functions to execute a simulation. First, your input must be read and initialized with the `read_input()` function. This function will create a `Simulation_Data` struct, typically named `SD` (but you can name it whatever you want), which contains all input data as well as the structures that will hold the results, but are empty initially. `SD` can then be given to the function `run_simulation(SD)`, which will modify it to include the simulation results.  
 Here is a minimum example on a random landscape, which will run a simulation of 20 timesteps without needing any input to be provided:
 
 ```julia

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -91,7 +91,7 @@ To run the simulation first load in your files as a [`Simulation_Data`](@ref) st
 function. Then run the simulation by using the [`run_simulation!()`](@ref) function on the `Simulation_Data` object.  
 
 ```julia
-SD = read_configs("./examples/static/")
+SD = read_input("./examples/static/")
 run_simulation!(SD)
 ```
 


### PR DESCRIPTION
Nothing special. Two minor fixes in the documentation.

**Note:** Despite the fact that we are getting an error from the Documentation CI (have a look [here](https://github.com/janablechschmidt/MetaRange.jl/issues/44) too), I'm marking it as ready as I'm pretty sure it is completely unrelated to the commits here. We still need to find the source of the errors though.