### PR TITLE
44 warnings in documentation ci became errors after merging

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,7 +20,6 @@ makedocs(;
         "Parameters" => "parameters.md",
         "Usage" => "usage.md",
     ],
-    warnonly=true,
 )
 
 deploydocs(; repo="github.com/janablechschmidt/MetaRange.jl", devbranch="main")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,7 +6,7 @@ DocMeta.setdocmeta!(MetaRange, :DocTestSetup, :(using MetaRange); recursive=true
 makedocs(;
     modules=[MetaRange],
     authors="janablechschmidt <jana.blechschmidt@uni-wuerzburg.de, rroelz <robin.roelz@gmail.com>",
-    repo= "",
+    repo="",
     sitename="MetaRange.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,7 +6,7 @@ DocMeta.setdocmeta!(MetaRange, :DocTestSetup, :(using MetaRange); recursive=true
 makedocs(;
     modules=[MetaRange],
     authors="janablechschmidt <jana.blechschmidt@uni-wuerzburg.de, rroelz <robin.roelz@gmail.com>",
-    repo="https://github.com/janablechschmidt/MetaRange.jl/blob/{commit}{path}#{line}",
+    repo= "",
     sitename="MetaRange.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
@@ -20,6 +20,7 @@ makedocs(;
         "Parameters" => "parameters.md",
         "Usage" => "usage.md",
     ],
+    warnonly=true,
 )
 
 deploydocs(; repo="github.com/janablechschmidt/MetaRange.jl", devbranch="main")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -16,6 +16,5 @@ Documentation for [MetaRange](https://github.com/janablechschmidt/MetaRange.jl).
 ```@docs
 read_input
 run_simulation!
-Simulation_Data
 default_run_data
 ```

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -38,7 +38,7 @@ configuration/
 ### Configuration File
 
 The configuration files are all formatted as space separated `.csv` files. This is the same minimal example as in
-`examples/static/`. More information on the configuration files can be found in the [parameters](@ref) section.  
+`examples/static/`. More information on the configuration files can be found in the [Parameters](@ref) section.  
 
 ```text
 Argument Value
@@ -56,7 +56,7 @@ Environment files are formatted as space separated `.csv` files. The model needs
 
 ### Species Files
 
-Several species files can be supplied to the model at the same time. Here is the example species file from `examples/static/`. More information on the species configuration files can be found in the [parameters](@ref) section.
+Several species files can be supplied to the model at the same time. Here is the example species file from `examples/static/`. More information on the species configuration files can be found in the [Parameters](@ref) section.
 
 ```text
 Argument Value


### PR DESCRIPTION
updated to work with Documenter v1.0.1 (and also fixed broken links) 