### PR TITLE
fix default_run_data()

### DIFF
--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -39,7 +39,7 @@ TBW
 """
 function get_testrun_simulation_parameters()
     #env_attribute_files = Dict{String, String}(
-      
+
     #  env_restriction_files = Dict{String, String}()
     A = Dict{String,Any}(
         "Argument" => "Value",
@@ -72,7 +72,7 @@ function get_testrun_simulation_parameters()
     end
     A["config_dir"] = config_path
     if A["input_backup"]
-        CSV.write(joinpath(config_path,"configuration.csv"),A)
+        CSV.write(joinpath(config_path, "configuration.csv"), A)
     end
     #return A
     init_out_dir(get_Simulation_Parameters(A))

--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -39,10 +39,12 @@ TBW
 """
 function get_testrun_simulation_parameters()
     #env_attribute_files = Dict{String, String}(
-    #  "precipitation" => "none",
-    #  "temperature" => "none")
+      
     #  env_restriction_files = Dict{String, String}()
     A = Dict{String,Any}(
+        "Argument" => "Value",
+        "precipitation" => "none",
+        "temperature" => "none",
         "experiment_name" => "testrun",
         "config_dir" => nothing,
         "output_dir" => "./output/",
@@ -64,12 +66,14 @@ function get_testrun_simulation_parameters()
         "initialize_cells" => "habitat",
         #"ls_cell_biomass_cap" => 200.0
     )
-    config_path = "./TESTRUN"
+    config_path = "./testrun"
     if !isdir(config_path)
         mkdir(config_path)
     end
     A["config_dir"] = config_path
-    #sp_sanity_checks!(A)
+    if A["input_backup"]
+        CSV.write(joinpath(config_path,"configuration.csv"),A)
+    end
     #return A
     init_out_dir(get_Simulation_Parameters(A))
     return get_Simulation_Parameters(A)
@@ -111,6 +115,7 @@ Returns a dictionary of default species
 """
 function species_default()
     return Dict{String,Any}(
+        "Argument" => "Value",
         "species_name" => "default",
         "mass" => "0.01",
         "sd_mass" => "0",

--- a/src/defaults.jl
+++ b/src/defaults.jl
@@ -48,7 +48,7 @@ function get_testrun_simulation_parameters()
         "output_dir" => "./output/",
         "species_dir" => "notreal",
         "environment_dir" => "notreal",
-        "input_backup" => false,
+        "input_backup" => true,
         "env_attribute_mode" => "minimum",
         "env_restriction_mode" => "minimum",
         "env_attribute_files" => Dict{String,String}(),
@@ -69,8 +69,9 @@ function get_testrun_simulation_parameters()
         mkdir(config_path)
     end
     A["config_dir"] = config_path
-    sp_sanity_checks!(A)
+    #sp_sanity_checks!(A)
     #return A
+    init_out_dir(get_Simulation_Parameters(A))
     return get_Simulation_Parameters(A)
 end
 

--- a/src/initialization_functions.jl
+++ b/src/initialization_functions.jl
@@ -525,6 +525,7 @@ function init_out_dir(SP::Simulation_Parameters)
         cp(SP.config_dir, backup_dir)
         configfile = joinpath(backup_dir, "configuration.csv")
         df = DataFrame(CSV.File(configfile))
+        rename!(df, Symbol.(["Argument", "Value"]))
         config = Dict{String,Any}(CSV.File(configfile))
         config["species_dir"] = replace(joinpath(backup_dir, "species"), "\\" => "/")
         config["environment_dir"] = replace(


### PR DESCRIPTION
deleted sanity test for default dataset, as the lack of environment dictionary caused an error. a copy of the default input is written in an "output" folder