### PR TITLE
`normpath()` to fix formatting

### DIFF
--- a/test/read_input.jl
+++ b/test/read_input.jl
@@ -9,20 +9,23 @@
             config = Dict{String,Any}(
                 "config_dir" => "/home/user/project/", "species_dir" => nothing
             )
-            @test MetaRange.get_species_dir(config) == "/home/user/project/species/"
+            @test MetaRange.get_species_dir(config) ==
+                normpath("/home/user/project/species/")
 
             # Test when species_dir is provided
             config = Dict{String,Any}(
                 "config_dir" => "/home/user/project/", "species_dir" => "my_species/"
             )
-            @test MetaRange.get_species_dir(config) == "/home/user/project/my_species/"
+            @test MetaRange.get_species_dir(config) ==
+                normpath("/home/user/project/my_species/")
         end
         @testset "get_environment_dir" begin
             # Test when environment_dir is not provided
             config = Dict{String,Any}(
                 "config_dir" => "/home/user/project/", "environment_dir" => nothing
             )
-            @test MetaRange.get_environment_dir(config) == "/home/user/project/environment/"
+            @test MetaRange.get_environment_dir(config) ==
+                normpath("/home/user/project/environment/")
 
             # Test when environment_dir is provided
             config = Dict{String,Any}(
@@ -30,7 +33,7 @@
                 "environment_dir" => "my_environment/",
             )
             @test MetaRange.get_environment_dir(config) ==
-                "/home/user/project/my_environment/"
+                normpath("/home/user/project/my_environment/")
         end
     end
 end


### PR DESCRIPTION
using `normpath` should fix the formatting between windows and unix in the tests and they shouldn't fail for no reason now. 
Closes #72 