### PR TITLE
normalize path when default is used

### DIFF
--- a/src/read_input.jl
+++ b/src/read_input.jl
@@ -154,7 +154,7 @@ the species folder is provided.
 """
 function get_environment_dir(config::Dict{String,Any})
     if isnothing(config["environment_dir"])
-        env_dir = joinpath(config["config_dir"], "environment/")
+        env_dir = normpath(joinpath(config["config_dir"], "environment/"))
     else
         env_dir = normpath(joinpath(config["config_dir"], config["environment_dir"]))
     end
@@ -169,7 +169,7 @@ species folder is provided.
 """
 function get_species_dir(config::Dict{String,Any})
     if isnothing(config["species_dir"])
-        spc_dir = joinpath(config["config_dir"], "species/")
+        spc_dir = normpath(joinpath(config["config_dir"], "species/"))
     else
         spc_dir = normpath(joinpath(config["config_dir"], config["species_dir"]))
     end


### PR DESCRIPTION
Not normalizing the path lead to errors in testing. I think it didn't lead to problems because in other parts the paths are normalized again but better safe than sorry. 
Closes #72 for real now (I hope)