### PR TITLE
Remove support for ltr

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -1,4 +1,4 @@
-name: CI
+name: build-documentation
 on:
   push:
     branches:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        julia-version: ['1.6', '1.9']
+        julia-version: ['1.9']
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ DataFrames = "1"
 DelimitedFiles = "1"
 Distributions = "0.25"
 Plots = "1"
-julia = "1.6"
+julia = "1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ julia> import Pkg; Pkg.add(url = "https://github.com/janablechschmidt/MetaRange.
 
 This will download all scripts, files, and dependencies that are necessary to run the model.
 
-MetaRange has been tested on Julia 1.6 and upwards on Windows and Linux.
+MetaRange is being developed and tested on the current 1.9 release on Windows and Linux.
 
 ## Usage
 


### PR DESCRIPTION
After some deliberation we decided to remove the support for the `1.6` long term release for Julia and move to the current stable release which at the moment is 1.9. 