### PR TITLE
remove dependency for JuliaFormatter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,6 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
-JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]


### PR DESCRIPTION
solve #111 
Since someone using MetaRange wouldn't need JuliaFormatter it's best to remove it. 