### PR TITLE
Bump makie

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 CSV = "0.10"
-CairoMakie = "0.10"
+CairoMakie = "0.11"
 DataFrames = "1"
 DelimitedFiles = "1"
 Distributions = "0.25"

--- a/src/output.jl
+++ b/src/output.jl
@@ -476,7 +476,7 @@ function plot_all(SD::Simulation_Data, t::Int)
         x_temp,
     )
 
-    f = Figure(; resolution=(1200, 800), figure_padding=1)
+    f = Figure(; size=(1200, 800), figure_padding=1)
 
     ratio =
         size(SD.species[1].output.abundances, 1) / size(SD.species[1].output.abundances, 2)
@@ -620,7 +620,7 @@ function all_gif(SD::Simulation_Data; frames=2)
         x_temp,
     )
 
-    f = Figure(; resolution=(1200, 800), figure_padding=1)
+    f = Figure(; size=(1200, 800), figure_padding=1)
 
     ratio =
         size(SD.species[1].output.abundances, 1) / size(SD.species[1].output.abundances, 2)


### PR DESCRIPTION
CairoMakie had a new release that deprecated the `resolution` keyword for nondiscrete units. Modified code according to release `0.11` and changed requirements. 