### PR TITLE
remove flooring of mean_dist to int, allow floats

### DIFF
--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -62,7 +62,7 @@ struct Traits
     "Species Parameter"
     max_dispersal_buffer::Int64 # not sure if needed at all
     "Species Parameter"
-    mean_dispersal_dist::Union{Int64, Float64}  # Species Parameter
+    mean_dispersal_dist::Union{Int64,Float64}  # Species Parameter
 
     "Allee effect counteracting negative diversity loss in small populations"
     allee::Float64

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -31,7 +31,7 @@ Traits of a species.
 - `param_const_growrate::Union{Float64, Nothing}`:
 - `max_dispersal_dist::Int64`:
 - `max_dispersal_buffer::Int64`:
-- `mean_dispersal_dist::Int64`:
+- `mean_dispersal_dist::Union{Int64, Float64}`:
 - `allee::Float64`: Allee effect counteracting negative diversity loss in small populations
 - `sd_allee::Float64`: Allee effect standard deviation
 - `param_const_allee::Union{Float64, Nothing}`:
@@ -62,7 +62,7 @@ struct Traits
     "Species Parameter"
     max_dispersal_buffer::Int64 # not sure if needed at all
     "Species Parameter"
-    mean_dispersal_dist::Int64  # Species Parameter
+    mean_dispersal_dist::Union{Int64, Float64}  # Species Parameter
 
     "Allee effect counteracting negative diversity loss in small populations"
     allee::Float64

--- a/src/initialization_functions.jl
+++ b/src/initialization_functions.jl
@@ -164,7 +164,7 @@ function parse_species_datatypes!(species::Dict)
             species[key] = parsed
         end
     end
-    for key in ("max_dispersal_dist", "mean_dispersal_dist")
+    for key in ("max_dispersal_dist")#, "mean_dispersal_dist")
         species[key] = floor(Int, species[key])
     end
 end

--- a/src/initialization_functions.jl
+++ b/src/initialization_functions.jl
@@ -164,9 +164,7 @@ function parse_species_datatypes!(species::Dict)
             species[key] = parsed
         end
     end
-    for key in ("max_dispersal_dist")#, "mean_dispersal_dist")
-        species[key] = floor(Int, species[key])
-    end
+    return species["max_dispersal_dist"] = floor(Int, species["max_dispersal_dist"])
 end
 
 """


### PR DESCRIPTION
fixes small bug with the mean dispersal distance, where it was always floored to int. now allows for the mean dispersal distance to be float or int. closes #126 